### PR TITLE
Fix urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ requests==2.22.0
 retrying==1.3.3
 six==1.13.0
 sqlparse==0.3.1
-urllib3==1.26.5
+urllib3==1.25.2
 virtualenv==16.7.7
 virtualenvwrapper-win==1.2.6
 webencodings==0.5.1


### PR DESCRIPTION
The previous version was incompatible with requests==2.22.0.

```
ERROR: requests 2.22.0 has requirement urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1, but you'll have urllib3 1.26.5 which is incompatible.
```